### PR TITLE
애플로그인 로직 수정

### DIFF
--- a/IMAD_Project/API/ApiClient.swift
+++ b/IMAD_Project/API/ApiClient.swift
@@ -12,7 +12,7 @@ final class ApiClient{
     
     var session:Session
     static let shared = ApiClient()
-    static let baseURL =  "https://\(Bundle.main.infoDictionary?["LOCAL_URL"] ?? "")"
+    static let baseURL =  "https://\(Bundle.main.infoDictionary?["BASE_URL"] ?? "")"
     
     let monitors = [ApiLogger()] as [EventMonitor]
     

--- a/IMAD_Project/API/ApiClient.swift
+++ b/IMAD_Project/API/ApiClient.swift
@@ -12,7 +12,7 @@ final class ApiClient{
     
     var session:Session
     static let shared = ApiClient()
-    static let baseURL =  "https://\(Bundle.main.infoDictionary?["BASE_URL"] ?? "")"
+    static let baseURL =  "https://\(Bundle.main.infoDictionary?["LOCAL_URL"] ?? "")"
     
     let monitors = [ApiLogger()] as [EventMonitor]
     

--- a/IMAD_Project/API/Router/AuthRouter.swift
+++ b/IMAD_Project/API/Router/AuthRouter.swift
@@ -14,7 +14,7 @@ enum AuthRouter:URLRequestConvertible{
     case register(email:String,password:String,authProvider:String)
     case login(email:String,password:String)
     case oauthDelete(authProvider:String)
-//    case appleLogin(accessToken:String,tokenType)
+    case appleLogin(state:String,code:String,user:String,idToken:String)
     case delete
    
     
@@ -32,11 +32,13 @@ enum AuthRouter:URLRequestConvertible{
             return "/api/user"
         case .oauthDelete(let authProvier):
             return "/api/oauth2/revoke/\(authProvier)"
+        case .appleLogin:
+            return "/api/api/callback/apple/token"
         }
     }
     var method:HTTPMethod{
         switch self{
-        case .login,.register:
+        case .login,.register,.appleLogin:
             return .post
         case .delete,.oauthDelete:
             return .delete
@@ -55,6 +57,13 @@ enum AuthRouter:URLRequestConvertible{
             param["password"] = password
             param["auth_provider"] = authProvider
             return param
+        case let .appleLogin(state, code, user, idToken):
+            var params = Parameters()
+            params["state"] = state
+            params["code"] = code
+            params["user"] = user
+            params["id_token"] = idToken
+            return params
         case .delete,.oauthDelete:
             return Parameters()
         }
@@ -65,7 +74,7 @@ enum AuthRouter:URLRequestConvertible{
         var request = URLRequest(url: url)
         request.method = method
         switch self{
-        case .login,.register:
+        case .login,.register,.appleLogin:
             return try JSONEncoding.default.encode(request, with: parameters)
         case .delete,.oauthDelete:
             return request

--- a/IMAD_Project/API/Router/AuthRouter.swift
+++ b/IMAD_Project/API/Router/AuthRouter.swift
@@ -14,7 +14,7 @@ enum AuthRouter:URLRequestConvertible{
     case register(email:String,password:String,authProvider:String)
     case login(email:String,password:String)
     case oauthDelete(authProvider:String)
-    case appleLogin(state:String,code:String,user:String,idToken:String)
+    case appleLogin(state:String?,code:String,user:String,idToken:String)
     case delete
    
     
@@ -33,7 +33,7 @@ enum AuthRouter:URLRequestConvertible{
         case .oauthDelete(let authProvier):
             return "/api/oauth2/revoke/\(authProvier)"
         case .appleLogin:
-            return "/api/api/callback/apple/token"
+            return "/api/callback/apple/token"
         }
     }
     var method:HTTPMethod{

--- a/IMAD_Project/API/Router/AuthRouter.swift
+++ b/IMAD_Project/API/Router/AuthRouter.swift
@@ -14,6 +14,7 @@ enum AuthRouter:URLRequestConvertible{
     case register(email:String,password:String,authProvider:String)
     case login(email:String,password:String)
     case oauthDelete(authProvider:String)
+//    case appleLogin(accessToken:String,tokenType)
     case delete
    
     

--- a/IMAD_Project/API/Service/AuthApiService.swift
+++ b/IMAD_Project/API/Service/AuthApiService.swift
@@ -54,15 +54,12 @@ enum AuthApiService{
             }
             .eraseToAnyPublisher()
     }
-    static func appleLogin(authorizationCode:String,userIdentity:String,state:String?,idToken:String){
+    static func appleLogin(authorizationCode:String,userIdentity:String,state:String?,idToken:String,compleion:@escaping (Bool)->()){
         print("애플로그인 api 호출")
         ApiClient.shared.session
             .request(AuthRouter.appleLogin(state: state, code: authorizationCode, user: userIdentity, idToken: idToken))
             .response{ response in
-                if let accessToken = response.response?.headers.dictionary["Authorization"],let refreshToken = response.response?.headers.dictionary["Authorization-refresh"]{
-                    UserDefaultManager.shared.setToken(accessToken: accessToken, refreshToken: refreshToken)
-                }
+                 compleion(UserDefaultManager.shared.checkToken(response: response.response))
             }
-            .validate(statusCode: 200..<300)
     }
 }

--- a/IMAD_Project/API/Service/AuthApiService.swift
+++ b/IMAD_Project/API/Service/AuthApiService.swift
@@ -54,18 +54,15 @@ enum AuthApiService{
             }
             .eraseToAnyPublisher()
     }
-    static func appleLogin(authorizationCode:String,userIdentity:String,state:String,idToken:String){
+    static func appleLogin(authorizationCode:String,userIdentity:String,state:String?,idToken:String){
         print("애플로그인 api 호출")
         ApiClient.shared.session
             .request(AuthRouter.appleLogin(state: state, code: authorizationCode, user: userIdentity, idToken: idToken))
             .response{ response in
                 if let accessToken = response.response?.headers.dictionary["Authorization"],let refreshToken = response.response?.headers.dictionary["Authorization-refresh"]{
-                    print(accessToken)
-                    print(refreshToken)
                     UserDefaultManager.shared.setToken(accessToken: accessToken, refreshToken: refreshToken)
                 }
             }
             .validate(statusCode: 200..<300)
     }
-    
 }

--- a/IMAD_Project/API/Service/AuthApiService.swift
+++ b/IMAD_Project/API/Service/AuthApiService.swift
@@ -54,5 +54,18 @@ enum AuthApiService{
             }
             .eraseToAnyPublisher()
     }
+    static func appleLogin(authorizationCode:String,userIdentity:String,state:String,idToken:String){
+        print("애플로그인 api 호출")
+        ApiClient.shared.session
+            .request(AuthRouter.appleLogin(state: state, code: authorizationCode, user: userIdentity, idToken: idToken))
+            .response{ response in
+                if let accessToken = response.response?.headers.dictionary["Authorization"],let refreshToken = response.response?.headers.dictionary["Authorization-refresh"]{
+                    print(accessToken)
+                    print(refreshToken)
+                    UserDefaultManager.shared.setToken(accessToken: accessToken, refreshToken: refreshToken)
+                }
+            }
+            .validate(statusCode: 200..<300)
+    }
+    
 }
-

--- a/IMAD_Project/API/Service/TokenApiService.swift
+++ b/IMAD_Project/API/Service/TokenApiService.swift
@@ -14,14 +14,10 @@ enum TokenApiService{
     
     static func getToken(completion: @escaping (Bool) -> Void){
             print("토큰 재발급 api 호출")
-            
-//            var getTokenSuccess = false
-            
             ApiClient.shared.session
                 .request(TokenRouter.token,interceptor: intercept)
                 .response{
                     completion(UserDefaultManager.shared.checkToken(response: $0.response))
-//                    return getTokenSuccess
                 }
             
         }

--- a/IMAD_Project/Config.xcconfig
+++ b/IMAD_Project/Config.xcconfig
@@ -13,6 +13,7 @@
 KAKAO_NATIVE_APP_KEY = dcee0f41332fb07eee3a8222002e16c0
 REST_API_KEY = 7bfd69d7c829f438bbbef2b046837935
 BASE_URL = api.iimad.com
+LOCAL_URL = www.ncookie.site
 APPLE_LOGIN_URL = appleid.apple.com/auth/authorize?client_id=com.iimad.api&redirect_uri
 APPLE_REDIRECT_URI = api.iimad.com/api/callback/apple&response_type=code%20id_token&scope=name%20email&response_mode=form_post
 

--- a/IMAD_Project/Core/Authentication/View/LoginAllView.swift
+++ b/IMAD_Project/Core/Authentication/View/LoginAllView.swift
@@ -11,7 +11,7 @@ import AuthenticationServices
 
 struct LoginAllView: View{
     
-//    @Environment(\.scenePhase) var scenePhase
+
     @State var oathFilter = OauthFilter(rawValue: "")
     @State var register = false
     
@@ -23,7 +23,6 @@ struct LoginAllView: View{
     
     @State var kakao = false
     @State var naver = false
-    @State var apple = false
     @State var google = false
     @State var domain = EmailFilter.gmail
     
@@ -61,29 +60,7 @@ struct LoginAllView: View{
             if loading{
                 CustomProgressView()
             }
-            //            if apple{
-            //                AuthWebView(filter: .Apple)
-            //                    .opacity(0)
-            //                    .ignoresSafeArea()
-            //                    .environmentObject(vm)
-            //                    .onDisappear{
-            //                        loading = false
-            //                    }
-            //            }
         }
-//        .onChange(of: scenePhase) { newValue in
-//            switch newValue {
-//            case .active:
-//                //               apple = false
-//                print("Active")
-//            case .inactive:
-//                print("Inactive")
-//            case .background:
-//                print("Background")
-//            default:
-//                print("scenePhase err")
-//            }
-//        }
         .onReceive(vm.loginSuccess){ value in
             success = true
             msg = value
@@ -92,27 +69,6 @@ struct LoginAllView: View{
             Alert(title: Text(msg),dismissButton: .cancel(Text("확인")){
                 loading = false
             })
-        }
-        //        .overlay(content: {
-        //            if apple{
-        //                AuthWebView(filter: .Apple)
-        //    //                    .opacity(0)
-        //                    .ignoresSafeArea()
-        //                    .environmentObject(vm)
-        //                    .onDisappear{
-        //                        loading = false
-        //                    }
-        //            }
-        //        })
-        .sheet(isPresented: $apple){
-            AuthWebView(filter: .Apple)
-                .ignoresSafeArea()
-                .environmentObject(vm)
-                .presentationDetents([.fraction(0)])
-                .onDisappear{
-                    loading = false
-                }
-            
         }
         .sheet(isPresented: $register) {
             RegisterView(login: $register)
@@ -287,36 +243,8 @@ extension LoginAllView{
                 request.requestedScopes = [.fullName, .email,]
             },
             onCompletion: { result in
-                switch result {
-                case .success(let authResults):
-                    print("Apple Login Successful")
-                    switch authResults.credential{
-                    case let appleIDCredential as ASAuthorizationAppleIDCredential:
-                        // 계정 정보 가져오기
-                        
-                        
-                        var params = Parameters()
-                        if let state = appleIDCredential.state{
-                            params["state"] = state
-                        }
-                        if let IdentityToken = String(data: appleIDCredential.identityToken!, encoding: .utf8){
-                            params["id_token"] = IdentityToken
-                        }
-                        let userIdentifier = appleIDCredential.user
-                        params["user"] = userIdentifier
-                        
-                        let email = appleIDCredential.email
-                        
-                        if let authoriztaion = String(data: appleIDCredential.authorizationCode!, encoding: .utf8){
-                            params["code"] = authoriztaion
-                        }
-                        
-                    default:
-                        break
-                    }
-                case .failure(let error):
-                    print(error.localizedDescription)
-                    print("error")
+                vm.appleLogin(result: result){
+//                    vm.getUser()
                 }
             }
         )

--- a/IMAD_Project/Core/Authentication/View/LoginAllView.swift
+++ b/IMAD_Project/Core/Authentication/View/LoginAllView.swift
@@ -243,9 +243,7 @@ extension LoginAllView{
                 request.requestedScopes = [.fullName, .email,]
             },
             onCompletion: { result in
-                vm.appleLogin(result: result){
-//                    vm.getUser()
-                }
+                vm.appleLogin(result: result)
             }
         )
         .frame(height:50)

--- a/IMAD_Project/Core/Authentication/View/LoginAllView.swift
+++ b/IMAD_Project/Core/Authentication/View/LoginAllView.swift
@@ -11,7 +11,7 @@ import AuthenticationServices
 
 struct LoginAllView: View{
     
-    @Environment(\.scenePhase) var scenePhase
+//    @Environment(\.scenePhase) var scenePhase
     @State var oathFilter = OauthFilter(rawValue: "")
     @State var register = false
     
@@ -59,29 +59,29 @@ struct LoginAllView: View{
             if loading{
                 CustomProgressView()
             }
-//            if apple{
-//                AuthWebView(filter: .Apple)
-//                    .opacity(0)
-//                    .ignoresSafeArea()
-//                    .environmentObject(vm)
-//                    .onDisappear{
-//                        loading = false
-//                    }
-//            }
+            //            if apple{
+            //                AuthWebView(filter: .Apple)
+            //                    .opacity(0)
+            //                    .ignoresSafeArea()
+            //                    .environmentObject(vm)
+            //                    .onDisappear{
+            //                        loading = false
+            //                    }
+            //            }
         }
-        .onChange(of: scenePhase) { newValue in
-           switch newValue {
-           case .active:
-//               apple = false
-               print("Active")
-           case .inactive:
-               print("Inactive")
-           case .background:
-               print("Background")
-           default:
-               print("scenePhase err")
-           }
-       }
+//        .onChange(of: scenePhase) { newValue in
+//            switch newValue {
+//            case .active:
+//                //               apple = false
+//                print("Active")
+//            case .inactive:
+//                print("Inactive")
+//            case .background:
+//                print("Background")
+//            default:
+//                print("scenePhase err")
+//            }
+//        }
         .onReceive(vm.loginSuccess){ value in
             success = true
             msg = value
@@ -91,17 +91,17 @@ struct LoginAllView: View{
                 loading = false
             })
         }
-//        .overlay(content: {
-//            if apple{
-//                AuthWebView(filter: .Apple)
-//    //                    .opacity(0)
-//                    .ignoresSafeArea()
-//                    .environmentObject(vm)
-//                    .onDisappear{
-//                        loading = false
-//                    }
-//            }
-//        })
+        //        .overlay(content: {
+        //            if apple{
+        //                AuthWebView(filter: .Apple)
+        //    //                    .opacity(0)
+        //                    .ignoresSafeArea()
+        //                    .environmentObject(vm)
+        //                    .onDisappear{
+        //                        loading = false
+        //                    }
+        //            }
+        //        })
         .sheet(isPresented: $apple){
             AuthWebView(filter: .Apple)
                 .ignoresSafeArea()
@@ -110,7 +110,7 @@ struct LoginAllView: View{
                 .onDisappear{
                     loading = false
                 }
-                
+            
         }
         .sheet(isPresented: $register) {
             RegisterView(login: $register)
@@ -282,33 +282,35 @@ extension LoginAllView{
     }
     var appleLoginButton:some View{
         SignInWithAppleButton(
-                    onRequest: { request in
-                        request.requestedScopes = [.fullName, .email]
-                    },
-                    onCompletion: { result in
-                        switch result {
-                        case .success(let authResults):
-                            print("Apple Login Successful")
-                            switch authResults.credential{
-                                case let appleIDCredential as ASAuthorizationAppleIDCredential:
-                                   // 계정 정보 가져오기
-                                    let UserIdentifier = appleIDCredential.user
-                                    let IdentityToken = String(data: appleIDCredential.identityToken!, encoding: .utf8)
-                                    let AuthorizationCode = String(data: appleIDCredential.authorizationCode!, encoding: .utf8)
-                                print("UserIdentifier   " + UserIdentifier)
-                                print("=====================")
-                                print("IdentityToken     \(String(describing: IdentityToken))")
-                                print("=====================")
-                                print("AuthorizationCode    \(String(describing: AuthorizationCode))")
-                            default:
-                                break
-                            }
-                        case .failure(let error):
-                            print(error.localizedDescription)
-                            print("error")
-                        }
+            onRequest: { request in
+                request.requestedScopes = [.fullName, .email]
+            },
+            onCompletion: { result in
+                switch result {
+                case .success(let authResults):
+                    print("Apple Login Successful")
+                    switch authResults.credential{
+                    case let appleIDCredential as ASAuthorizationSingleSignOnCredential:
+                        // 계정 정보 가져오기
+//                        let userIdentifier = String(data: appleIDCredential., encoding: <#T##String.Encoding#>)
+                        let accessToken = String(data: appleIDCredential.accessToken!, encoding: .utf8)
+                        let IdentityToken = String(data: appleIDCredential.identityToken!, encoding: .utf8)
+                        
+//                        print("UserIdentifier   " + userIdentifier)
+                        print("=====================")
+                        print("IdentityToken     \(String(describing: IdentityToken))")
+                        print("=====================")
+                        print("accessToken    \(String(describing: accessToken))")
+                        
+                    default:
+                        break
                     }
-                )
+                case .failure(let error):
+                    print(error.localizedDescription)
+                    print("error")
+                }
+            }
+        )
     }
     func loginButton(item:OauthFilter) -> some View{
         RoundedRectangle(cornerRadius: 20).frame(height: 55)


### PR DESCRIPTION
#102 - 애플로그인 로직 수정

> 수정 이유
- 애플로그인은 웹뷰화면을 사용하지 않는데 웹뷰를 사용하지 않지만, 받는 데이터형식이 `HTML`이였기 때문에 필연적으로 웹뷰가 필요했음
- 이 과정이 불필요하다고 느끼고 다른 로직이 있을 것이라 생각하여 찾아본 결과 iOS에서 자체적으로 제공하는 애플로그인 SDK를 사용하는 방향 채택
- 서버 개발자와의 회의 끝에 애플SDK 로그인 방식으로 로직을 변경하기로 결정함

> 기존 로직
1. WebView를 통해 서버에 특정 auth provider로 로그인화면 요청
2. WebView가 나타나고 해당 요청에 `redirect URI`로 인한 애플 로그인 Modal이 생성됨
3. 로그인 완료 후 WebView에서 받은 토큰을 저장하여 로그인 성공

> 변경된 로직
1. 애플로그인 버튼 클릭 후 받아온 정보들을 Api Server로 전송
4. 서버는 받은 정보를 토대로 토큰을 제작해 클라이언트에게 전송
5. 클라이언트에서 토큰을 받아 저장

> 결과

애플 자체 로그인 시 받은 `authorization code`,` user identity`, `state`, `id token` 등의 정보로 다시 요청을 걸기만 하면 되는 구조임으로 비교적 클라이언트의 수고가 덜어질 것이라 생각하고 실행한 로직이였고, 예상처럼 쉽게 해결할 수 있었음

다만 서버입장에서 구현해야할 내용이 많아 각자 개발 밸런스를 맞추지는 못했지만, 애플이 권장하는 로그인 방법에 더욱 부합하게 구현 했다고 생각함
