### PR TITLE
#129 - 작품품 상세화면에서 배우 및 스태프 이미지를 전혀 불러오지 못하는 문제 해결

### DIFF
--- a/IMAD_Project.xcodeproj/project.pbxproj
+++ b/IMAD_Project.xcodeproj/project.pbxproj
@@ -178,6 +178,7 @@
 		81F3566E2AF21F1D00A46A6D /* MyBookmarkListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81F3566D2AF21F1D00A46A6D /* MyBookmarkListView.swift */; };
 		81FF75AE2AF8C4DE00DB1AC2 /* ProfileImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81FF75AD2AF8C4DE00DB1AC2 /* ProfileImageView.swift */; };
 		81FF75B02AF8CE7600DB1AC2 /* ScoreView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81FF75AF2AF8CE7600DB1AC2 /* ScoreView.swift */; };
+		D60A53812C61E81B001F73F2 /* Documentation.docc in Sources */ = {isa = PBXBuildFile; fileRef = D60A53802C61E81B001F73F2 /* Documentation.docc */; };
 		D60AD1EA2C294DA900C9C27B /* RecommendTVResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = D60AD1E92C294DA900C9C27B /* RecommendTVResponse.swift */; };
 		D60AD1EC2C2952DB00C9C27B /* AllRecommend.swift in Sources */ = {isa = PBXBuildFile; fileRef = D60AD1EB2C2952DB00C9C27B /* AllRecommend.swift */; };
 		D60AD1F22C29549600C9C27B /* GenreRecommendResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = D60AD1F12C29549600C9C27B /* GenreRecommendResponse.swift */; };
@@ -426,6 +427,7 @@
 		81F3566D2AF21F1D00A46A6D /* MyBookmarkListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyBookmarkListView.swift; sourceTree = "<group>"; };
 		81FF75AD2AF8C4DE00DB1AC2 /* ProfileImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileImageView.swift; sourceTree = "<group>"; };
 		81FF75AF2AF8CE7600DB1AC2 /* ScoreView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScoreView.swift; sourceTree = "<group>"; };
+		D60A53802C61E81B001F73F2 /* Documentation.docc */ = {isa = PBXFileReference; lastKnownFileType = folder.documentationcatalog; path = Documentation.docc; sourceTree = "<group>"; };
 		D60AD1E92C294DA900C9C27B /* RecommendTVResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecommendTVResponse.swift; sourceTree = "<group>"; };
 		D60AD1EB2C2952DB00C9C27B /* AllRecommend.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AllRecommend.swift; sourceTree = "<group>"; };
 		D60AD1F12C29549600C9C27B /* GenreRecommendResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenreRecommendResponse.swift; sourceTree = "<group>"; };
@@ -552,6 +554,7 @@
 				8103094629D1BDF00021717B /* Preview Content */,
 				81BB11292A0642E8005654AA /* Config.xcconfig */,
 				81EE0B432B4161DF00A58E5F /* IMAD-Project-info.plist */,
+				D60A53802C61E81B001F73F2 /* Documentation.docc */,
 			);
 			path = IMAD_Project;
 			sourceTree = "<group>";
@@ -1641,6 +1644,7 @@
 				817919C82B4BADC30084779B /* CustomTextEditor.swift in Sources */,
 				817919D12B4BDFA70084779B /* RankingResponse.swift in Sources */,
 				8131C55E2AFA0CC9006B761D /* WriteReviewResponse.swift in Sources */,
+				D60A53812C61E81B001F73F2 /* Documentation.docc in Sources */,
 				81A1ECE329DC207F0001A366 /* ColorSet.swift in Sources */,
 				817B60D62A23747F000099A9 /* ValidationResponse.swift in Sources */,
 				8154B1DF2ADCE64E00AD2F83 /* CommunityList.swift in Sources */,

--- a/IMAD_Project/Core/Custom/View/Components/Widget/Elements/ProfileImageView.swift
+++ b/IMAD_Project/Core/Custom/View/Components/Widget/Elements/ProfileImageView.swift
@@ -9,10 +9,11 @@ import SwiftUI
 import Kingfisher
 
 struct ProfileImageView: View {
+    var work:Int?
     let imagePath:String
     let widthHeigt:CGFloat
     var body: some View {
-        KFImage(URL(string: imagePath.getImageURL()))
+        KFImage(URL(string: work != nil ? imagePath.getImadImage():imagePath.getImageURL()))
             .resizable()
             .placeholder{
                 Circle()
@@ -33,12 +34,15 @@ struct ProfileImageView: View {
                         .shadow(color:ProfileFilter.allCases.first(where: {$0.num == imagePath.getImageCode()})?.color ?? .clear,radius: 1)
                 }
             }
+            .onAppear{
+                print(imagePath.getImadImage())
+            }
     }
    
 }
 
 struct ProfileImageView_Previews: PreviewProvider {
     static var previews: some View {
-        ProfileImageView(imagePath: CustomData.instance.profileImage,widthHeigt: 30)
+        ProfileImageView(work: 1, imagePath: CustomData.instance.profileImage,widthHeigt: 30)
     }
 }

--- a/IMAD_Project/Core/Work/View/WorkInfoView.swift
+++ b/IMAD_Project/Core/Work/View/WorkInfoView.swift
@@ -304,7 +304,7 @@ extension WorkInfoView{
             if let crews = work.credits?.crew,!crews.isEmpty{
                 ForEach(crews){ crew in
                     HStack{
-                        ProfileImageView(imagePath: crew.profilePath ?? "", widthHeigt: 80)
+                        ProfileImageView(work:1,imagePath: crew.profilePath ?? "", widthHeigt: 80)
                         VStack(alignment: .leading){
                             Text(crew.name ?? "")
                             if let jobs = crew.job?.components(separatedBy: ","){
@@ -331,7 +331,7 @@ extension WorkInfoView{
             if let casts = work.credits?.cast,casts != []{
                 ForEach(casts){ cast in
                     HStack{
-                        ProfileImageView(imagePath:cast.profilePath ?? "" , widthHeigt: 80)
+                        ProfileImageView(work:1,imagePath:cast.profilePath ?? "" , widthHeigt: 80)
                         VStack(alignment: .leading){
                             Text(cast.name ?? "")
                             Text("\(cast.character ?? "")역")

--- a/IMAD_Project/Documentation.docc/Documentation.md
+++ b/IMAD_Project/Documentation.docc/Documentation.md
@@ -1,0 +1,13 @@
+# ``IMAD_Project``
+
+<!--@START_MENU_TOKEN@-->Summary<!--@END_MENU_TOKEN@-->
+
+## Overview
+
+<!--@START_MENU_TOKEN@-->Text<!--@END_MENU_TOKEN@-->
+
+## Topics
+
+### <!--@START_MENU_TOKEN@-->Group<!--@END_MENU_TOKEN@-->
+
+- <!--@START_MENU_TOKEN@-->``Symbol``<!--@END_MENU_TOKEN@-->

--- a/IMAD_Project/Documentation.docc/ListView.md
+++ b/IMAD_Project/Documentation.docc/ListView.md
@@ -1,0 +1,20 @@
+# ``IMad_Project/ListView``
+
+dasjknasdnaskjdnaskdjnasdkja
+
+<!--@START_MENU_TOKEN@-->Summary<!--@END_MENU_TOKEN@-->
+
+## Overview
+
+asdasdad
+
+<!--@START_MENU_TOKEN@-->Text<!--@END_MENU_TOKEN@-->
+
+## Topics
+
+### <!--@START_MENU_TOKEN@-->Group<!--@END_MENU_TOKEN@-->
+
+- <!--@START_MENU_TOKEN@-->``Symbol``<!--@END_MENU_TOKEN@-->
+- dasdasdasd
+- sdasdasdasd
+- dsadasdasd


### PR DESCRIPTION
- 코드 리펙토링 중 유저 프로필 이미지와 배우 및 스태프 이미지의 프로필을 같은 url을 사용해서 유저 프로필만 불러왔었음
- 예외처리로 문제 해결