### PR TITLE
#142 - Apple로그인 안되는 문제 해결

### DIFF
--- a/IMAD_Project/Core/Authentication/View/AuthWebView.swift
+++ b/IMAD_Project/Core/Authentication/View/AuthWebView.swift
@@ -33,6 +33,7 @@ struct AuthWebView: View {
             Color.white
             filter.color
         }
+        .ignoresSafeArea()
         .onAppear {
             // 로드될 페이지 설정
             let url = URL(string: "\(ApiClient.baseURL)\(endPoint)\(filter.authProvierName)")!

--- a/IMAD_Project/Core/Authentication/View/WebView.swift
+++ b/IMAD_Project/Core/Authentication/View/WebView.swift
@@ -43,8 +43,10 @@ class WebViewDelegate: NSObject, WKNavigationDelegate {
             return
         }
         decisionHandler(.allow)
-        if (200...300) ~= httpResponse.statusCode,UserDefaultManager.shared.checkToken(response: httpResponse) {
-            success.send()
+        if (200...300) ~= httpResponse.statusCode{
+            if UserDefaultManager.shared.checkToken(response: httpResponse) {
+                success.send()
+            }
         }
         else{
             failed.send()

--- a/IMAD_Project/Filter/OauthFilter.swift
+++ b/IMAD_Project/Filter/OauthFilter.swift
@@ -8,13 +8,15 @@
 import Foundation
 import SwiftUI
 
-enum OauthFilter:String,CaseIterable{
+enum OauthFilter:String,Identifiable,CaseIterable{
     case Apple
     case naver
     case kakao
     case google
     case none
-    
+    var id:UUID{
+        UUID(uuidString: self.rawValue) ?? UUID()
+    }
     var color:Color{
         switch self{
         case .Apple:


### PR DESCRIPTION
배경을 터치했을 때의 제스쳐와 AppleLogin버튼의 터치 제스쳐가 겹쳐서 발생(길게 터치할 때만 터치됨)
- AuthWebView : safe area영역이 현재 시스템 색상으로 되있어서 웹뷰 자체의 safeArea 영역을 확장  
- LoginView : sheet의 동작이 원활하지 않았던 문제 해결(isPresent,와 필터가 동시에 업데이트가 되지 않아 item으로 동작하도록 수정)
- WebView : 첫 등장 시 토큰이 없을 경우 바로 실패로 처리해버려 바로 뷰가 내려가는 로직의 조건을 수정해 웹뷰를 불러오고 로그인을 완료해야 웹뷰가 내려가도록 수정 
- OauthFilter : sheet를 헨들링하기 위해 필터에 Idenfier프로토콜 준수